### PR TITLE
Fix for there is no [ceilometer.publisher] section in entry points file in pike release #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ send samples to Monasca:
 
 3. Edit the entry points file to add the following entries:
 
-   At `[ceilometer.publisher]` section:
+   At `[ceilometer.sample.publisher]` section:
    ```
    monasca = ceilometer.publisher.monclient:MonascaPublisher
    ```


### PR DESCRIPTION
There is no [ceilometer.publisher] section in the entry points file of ceilometer in pike release but there are [ceilometer.event.publisher] and [ceilometer.sample.publisher] section in the entry files.

Add the following line to the [ceilometer.sample.publisher] section:
monasca = ceilometer.publisher.monclient:MonascaPublisher

Event publishing isn’t supported in Monasca-Ceilometer yet, so we don’t need to edit ceilometer.event.publisher